### PR TITLE
feat: advanced block details

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -36,7 +36,7 @@ useHead({
 
 <style>
   body {
-    background-color: #131313;
+    background-color: #171717;
     height: 100%;
   }
 

--- a/components/LabelValue.vue
+++ b/components/LabelValue.vue
@@ -3,6 +3,7 @@ defineProps<{
   label: string;
   value?: string | number;
   col?: boolean;
+  row?: boolean;
   withCopy?: boolean;
   description?: string;
   copyTooltip?: string;
@@ -15,11 +16,15 @@ defineProps<{
     class="flex flex-col md:flex-row"
     :class="[
       col && '!flex-col !items-start',
+      row && '!flex-row !gap-6',
       value && 'md:items-center'
     ]"
   >
     <div
-      class="w-full min-w-[300px] max-w-[300px] h-full flex gap-2"
+      class="flex gap-2"
+      :class="[
+        !row && 'w-full h-fullmin-w-[300px] max-w-[300px]',
+      ]"
     >
       <Tooltip
         v-if="description"

--- a/components/LabelValue.vue
+++ b/components/LabelValue.vue
@@ -6,6 +6,7 @@ defineProps<{
   withCopy?: boolean;
   description?: string;
   copyTooltip?: string;
+  tooltipPos?: 'top' | 'right' | 'bottom' | 'left';
 }>()
 </script>
 
@@ -23,6 +24,8 @@ defineProps<{
       <Tooltip
         v-if="description"
         :value="description"
+        :placement="tooltipPos"
+        :offset-distance="16"
       >
         <span
           class="text-[#bbbbbb] text-[15px] font-normal"

--- a/components/LabelValue.vue
+++ b/components/LabelValue.vue
@@ -23,9 +23,15 @@ defineProps<{
       <Tooltip
         v-if="description"
         :value="description"
-      />
-
+      >
+        <span
+          class="text-[#bbbbbb] text-[15px] font-normal"
+        >
+          {{ label }}
+        </span>
+      </Tooltip>
       <span
+        v-else
         class="text-[#bbbbbb] text-[15px] font-normal"
       >
         {{ label }}

--- a/components/LabelValue.vue
+++ b/components/LabelValue.vue
@@ -5,7 +5,7 @@ defineProps<{
   col?: boolean;
   withCopy?: boolean;
   description?: string;
-  tooltipText?: string;
+  copyTooltip?: string;
 }>()
 </script>
 
@@ -46,7 +46,7 @@ defineProps<{
         </span>
 
         <Copy
-          :tooltipText="tooltipText"
+          :tooltipText="copyTooltip"
           v-if="withCopy && value"
           :value="value"
         />

--- a/components/LabelValue.vue
+++ b/components/LabelValue.vue
@@ -18,7 +18,7 @@ defineProps<{
     ]"
   >
     <div
-      class="w-full min-w-[300px] max-w-[300px] h-full flex items-center gap-2"
+      class="w-full min-w-[300px] max-w-[300px] h-full flex gap-2"
     >
       <Tooltip
         v-if="description"

--- a/components/Tooltip.vue
+++ b/components/Tooltip.vue
@@ -57,9 +57,9 @@ const tooltipClass = computed(() => {
           v-show="isVisible"
           :class="tooltipClass"
         >
-          <div class="bg-[#313131] text-[#e5e5e5] text-xs px-2 py-1 rounded-md shadow-lg relative text-center">
+          <div class="z-[10] bg-[#313131] text-[#e5e5e5] text-xs px-2 py-1 rounded-md shadow-lg relative text-center isolate">
             {{ value }}
-            <div class="absolute w-3 h-3 bg-[#313131] rotate-45 left-1/2 -translate-x-1/2 bottom-[-4px]"></div>
+            <div class="-z-10 absolute w-3 h-3 bg-[#313131] rotate-45 left-1/2 -translate-x-1/2 bottom-[-4px]"></div>
           </div>
         </div>
       </Transition>

--- a/components/Tooltip.vue
+++ b/components/Tooltip.vue
@@ -7,14 +7,16 @@ const props = withDefaults(defineProps<{
   variant?: 'default' | 'hash',
   offsetDistance?: number,
   disabled?: boolean,
+  placement?: 'top' | 'right' | 'bottom' | 'left',
 }>(), {
   offsetDistance: 4,
   disabled: false,
+  placement: 'top',
 });
 
 const isVisible = ref(false);
 const [reference, popper, instance] = usePopper({
-  placement: 'top',
+  placement: props.placement,
   offsetDistance: props.offsetDistance
 });
 
@@ -40,6 +42,22 @@ const tooltipClass = computed(() => {
   }
   return `${base} max-w-[200px]`;
 });
+
+const arrowClass = computed(() => {
+  const base = '-z-10 absolute w-3 h-3 bg-[#313131] rotate-45';
+  switch (props.placement) {
+    case 'top':
+      return `${base} left-1/2 -translate-x-1/2 bottom-[-4px]`;
+    case 'right':
+      return `${base} left-[-4px] top-1/2 -translate-y-1/2`;
+    case 'bottom':
+      return `${base} left-1/2 -translate-x-1/2 top-[-4px]`;
+    case 'left':
+      return `${base} right-[-4px] top-1/2 -translate-y-1/2`;
+    default:
+      return '';
+  }
+});
 </script>
 
 <template>
@@ -59,7 +77,7 @@ const tooltipClass = computed(() => {
         >
           <div class="z-[10] bg-[#313131] text-[#e5e5e5] text-xs px-2 py-1 rounded-md shadow-lg relative text-center isolate">
             {{ value }}
-            <div class="-z-10 absolute w-3 h-3 bg-[#313131] rotate-45 left-1/2 -translate-x-1/2 bottom-[-4px]"></div>
+            <div :class="arrowClass"></div>
           </div>
         </div>
       </Transition>

--- a/components/skeleton/BlockDetails.vue
+++ b/components/skeleton/BlockDetails.vue
@@ -1,9 +1,8 @@
 <template>
   <div>
     <!-- Header Skeleton -->
-    <div class="flex items-center pb-5 border-b border-[#222222] mb-6 gap-2">
-      <div class="h-6 w-24 bg-gray-600 rounded animate-pulse"></div>
-      <div class="h-6 w-24 bg-gray-600 rounded animate-pulse"></div>
+    <div class="flex items-center mb-2 gap-2">
+      <div class="h-7 w-20 bg-gray-600 rounded-lg animate-pulse"></div>
     </div>
 
     <!-- Main Content Skeleton -->
@@ -31,7 +30,7 @@
 
     <!-- More Details Card Skeleton -->
     <div class="bg-[#111111] border border-[#222222] rounded-xl shadow-[0_0_20px_rgba(255,255,255,0.0625)] p-5 mt-4">
-      <div class="h-5 w-1/4 bg-gray-600 rounded animate-pulse"></div>
+      <div class="h-5 w-2/5 bg-gray-600 rounded animate-pulse"></div>
     </div>
   </div>
 </template> 

--- a/composables/useBinance.ts
+++ b/composables/useBinance.ts
@@ -18,6 +18,25 @@ export const useBinance = () => {
     }
   };
 
+  const fetchKadenaTickerData = async () => {
+    try {
+      const response = await $fetch('/api/binance', {
+        method: 'POST',
+        body: {
+          action: 'getKadenaTickerData',
+          params: {
+            symbol: 'KDAUSDT',
+          },
+        },
+      });
+
+      return response;
+    } catch (error) {
+      console.error('Error fetching Kadena ticker data:', error);
+      return null;
+    }
+  };
+
   const fetchKadenaCandlestickData = async (
     interval: string = '1d',
     limit: number = 30
@@ -72,6 +91,7 @@ export const useBinance = () => {
 
   return {
     fetchKadenaPrice,
+    fetchKadenaTickerData,
     fetchKadenaCandlestickData,
     fetchKadenaPriceAtTimestamp,
   };

--- a/composables/useBinance.ts
+++ b/composables/useBinance.ts
@@ -61,7 +61,7 @@ export const useBinance = () => {
     }
   };
 
-  const fetchKadenaPriceAtTimestamp = async (timestamp: string) => {
+  const fetchKadenaPriceAtDate = async (timestamp: Date) => {
     try {
       const response: any = await $fetch('/api/binance', {
         method: 'POST',
@@ -69,8 +69,8 @@ export const useBinance = () => {
           action: 'getKadenaCandlestickData',
           params: {
             symbol: 'KDAUSDT',
-            interval: '1m',
-            startTime: new Date(timestamp).getTime(),
+            interval: '1d',
+            startTime: timestamp.getTime(),
             limit: 1,
           },
         },
@@ -93,6 +93,6 @@ export const useBinance = () => {
     fetchKadenaPrice,
     fetchKadenaTickerData,
     fetchKadenaCandlestickData,
-    fetchKadenaPriceAtTimestamp,
+    fetchKadenaPriceAtDate,
   };
 }; 

--- a/composables/useBinance.ts
+++ b/composables/useBinance.ts
@@ -1,0 +1,78 @@
+export const useBinance = () => {
+  const fetchKadenaPrice = async () => {
+    try {
+      const response = await $fetch('/api/binance', {
+        method: 'POST',
+        body: {
+          action: 'getKadenaPrice',
+          params: {
+            symbol: 'KDAUSDT',
+          },
+        },
+      });
+
+      return response;
+    } catch (error) {
+      console.error('Error fetching Kadena price:', error);
+      return null;
+    }
+  };
+
+  const fetchKadenaCandlestickData = async (
+    interval: string = '1d',
+    limit: number = 30
+  ) => {
+    try {
+      const response = await $fetch('/api/binance', {
+        method: 'POST',
+        body: {
+          action: 'getKadenaCandlestickData',
+          params: {
+            symbol: 'KDAUSDT',
+            interval,
+            limit,
+          },
+        },
+      });
+
+      return response;
+    } catch (error) {
+      console.error('Error fetching Kadena candlestick data:', error);
+      return null;
+    }
+  };
+
+  const fetchKadenaPriceAtTimestamp = async (timestamp: string) => {
+    try {
+      const response: any = await $fetch('/api/binance', {
+        method: 'POST',
+        body: {
+          action: 'getKadenaCandlestickData',
+          params: {
+            symbol: 'KDAUSDT',
+            interval: '1m',
+            startTime: new Date(timestamp).getTime(),
+            limit: 1,
+          },
+        },
+      });
+
+      // The response for a single kline is an array within an array, e.g., [[timestamp, open, high, low, close, ...]]
+      // We return the close price.
+      if (response.data && response.data.length > 0 && response.data[0].length > 4) {
+        return { price: response.data[0][4] };
+      }
+
+      return null;
+    } catch (error) {
+      console.error('Error fetching Kadena historical price:', error);
+      return null;
+    }
+  };
+
+  return {
+    fetchKadenaPrice,
+    fetchKadenaCandlestickData,
+    fetchKadenaPriceAtTimestamp,
+  };
+}; 

--- a/composables/useBlock.ts
+++ b/composables/useBlock.ts
@@ -190,7 +190,6 @@ export const useBlock = (
     } catch (e) {
       error.value = e;
       block.value = null;
-      console.error('Error fetching or processing block:', e);
     } finally {
       loading.value = false;
     }

--- a/composables/useBlock.ts
+++ b/composables/useBlock.ts
@@ -67,19 +67,19 @@ const BLOCK_TRANSACTIONS_QUERY = `
   }
 `;
 
+const block = ref<any>(null);
+const competingBlocks = ref<any[]>([]);
+const canonicalIndex = ref(-1);
+const loading = ref(true);
+const error = ref<any>(null);
+const totalGasUsed = ref<number | null>(null);
+const gasLoading = ref(false);
+
 export const useBlock = (
   height: Ref<number>,
   chainId: Ref<number>,
   networkId: Ref<string | undefined>
 ) => {
-  const block = ref<any>(null);
-  const competingBlocks = ref<any[]>([]);
-  const canonicalIndex = ref(-1);
-  const loading = ref(true);
-  const error = ref<any>(null);
-  const totalGasUsed = ref<number | null>(null);
-  const gasLoading = ref(false);
-
   const calculateTotalGas = async () => {
     if (!block.value || !networkId.value) {
       return;
@@ -136,7 +136,7 @@ export const useBlock = (
       return;
     }
 
-    loading.value = true;
+    loading.value = block.value === null;
     error.value = null;
     competingBlocks.value = [];
     canonicalIndex.value = -1;

--- a/composables/useFormat.ts
+++ b/composables/useFormat.ts
@@ -73,10 +73,23 @@ export const useFormat = () => {
     return feeStr.replace(/(\.\d*[1-9])0+$/, '$1').replace(/\.0+$/, '.0');
   };
 
+  const removeTrailingZeros = (value: string | number | null | undefined): string => {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    const stringValue = String(value);
+    const num = parseFloat(stringValue);
+    if (isNaN(num)) {
+      return stringValue;
+    }
+    return num.toString();
+  };
+
   return {
     truncateAddress,
     formatRelativeTime,
     formatFullDate,
     formatGasPrice,
+    removeTrailingZeros,
   };
 }; 

--- a/composables/useScreenSize.ts
+++ b/composables/useScreenSize.ts
@@ -1,0 +1,26 @@
+import { ref, onMounted, onUnmounted } from 'vue';
+
+export function useScreenSize() {
+  const isMobile = ref(false);
+
+  const checkScreenSize = () => {
+    if (typeof window !== 'undefined') {
+      isMobile.value = window.innerWidth < 768;
+    }
+  };
+
+  onMounted(() => {
+    checkScreenSize();
+    window.addEventListener('resize', checkScreenSize);
+  });
+
+  onUnmounted(() => {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('resize', checkScreenSize);
+    }
+  });
+
+  return {
+    isMobile,
+  };
+} 

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -251,10 +251,10 @@ useHead({
                   <template #value>
                     <div
                       v-if="blockStatus"
-                      class="px-2 py-1 text-[12px] rounded-md border flex items-center gap-1"
+                      class="px-2 py-1.5 text-[11px] rounded-md border flex items-center gap-1 leading-none"
                       :class="blockStatus.classes"
                     >
-                      <component :is="blockStatus.icon" class="w-3 h-3" />
+                      <component :is="blockStatus.icon" class="w-2.5 h-2.5" />
                       <span>
                         {{ blockStatus.text }}
                       </span>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -74,7 +74,7 @@ const blockStatus = computed(() => {
 
   if(lastBlockHeight.value - 8 >= block.value.height && !block.value.canonical) {
     return {
-      text: 'Failed',
+      text: 'Orphaned',
       icon: IconCancel,
       classes: 'bg-[#7f1d1d66] border-[#f87171] text-[#f87171]',
     };
@@ -82,14 +82,14 @@ const blockStatus = computed(() => {
 
   if(block.value.canonical) {
     return {
-      text: 'Finalized',
+      text: 'Canonical',
       icon: IconCheckmarkFill,
       classes: 'bg-[#0f1f1d] border-[#00a186] text-[#00a186]',
     };
   }
 
   return {
-    text: 'Pending',
+    text: 'Unconfirmed',
     icon: IconHourglass,
     classes: 'bg-[#17150d] border-[#eab308] text-[#eab308]',
   };
@@ -163,17 +163,6 @@ useHead({
           @click="activeView = 'overview'"
         >
           Overview
-        </button>
-        <button
-          class="px-[10px] py-[5px] text-[13px] rounded-lg border font-medium transition-colors bg-[#009367] border-[#222222] text-[#f5f5f5]"
-          :class="{
-            'bg-[#009367] text-[#f5f5f5]': activeView === 'neighbors',
-            'bg-transparent text-[#bbbbbb] hover:bg-[#222222]':
-              activeView !== 'neighbors',
-          }"
-          @click="activeView = 'neighbors'"
-        >
-          Neighbors
         </button>
       </div>
 
@@ -273,7 +262,7 @@ useHead({
                   <template #value>
                     <Tooltip value="Click to view Transactions">
                       <NuxtLink
-                        :to="`/transactions?block=${block.hash}&chainId=${block.chainId}`"
+                        :to="`/transactions?block=${block.height}&chainId=${block.chainId}`"
                         class="text-[#6ab5db] hover:text-[#9ccee7]"
                       >
                         {{ block.transactions.totalCount }} transactions
@@ -340,11 +329,14 @@ useHead({
             </DivideItem>
           </Divide>
         </div>
+
+        <!-- More Details -->
         <div
           v-if="!loading && !error && block"
           class="bg-[#111111] border border-[#222222] rounded-xl shadow-[0_0_20px_rgba(255,255,255,0.0625)] p-5"
         >
           <Divide>
+            <!-- Epoch -->
             <DivideItem v-if="showMore">
               <div class="flex flex-col gap-4">
                 <LabelValue
@@ -356,6 +348,8 @@ useHead({
                 <LabelValue label="Weight" :value="block.weight" />
               </div>
             </DivideItem>
+
+            <!-- Hash -->
             <DivideItem v-if="showMore">
               <div class="flex flex-col gap-4">
                 <LabelValue label="Hash" :value="block.hash" />
@@ -389,6 +383,38 @@ useHead({
                 />
               </div>
             </DivideItem>
+
+            <!-- Neighbors -->
+            <DivideItem v-if="showMore">
+              <div
+                v-if="block.neighbors && block.neighbors.length > 0"
+                class="flex flex-col gap-4"
+              >
+                <div
+                  v-for="neighbor in block.neighbors"
+                  :key="neighbor.hash"
+                  class="flex items-center"
+                >
+                  <span class="text-[#bbbbbb] text-[15px] min-w-[300px]">Neighbor at Chain #{{ neighbor.chainId }}</span>
+                  <div class="flex items-center gap-2">
+                    <NuxtLink
+                      :to="`/blocks/${block.height}/chain/${neighbor.chainId}`"
+                      class="text-[15px] text-[#6ab5db] hover:text-[#9ccee7]"
+                      >{{ neighbor.hash }}</NuxtLink
+                    >
+                    <Copy
+                      :value="neighbor.hash"
+                      tooltipText="Copy Block Hash"
+                      iconSize="h-5 w-5"
+                      buttonClass="w-5 h-5"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div v-else class="text-gray-500">No neighbors found for this block.</div>         
+            </DivideItem>
+
+            <!-- More Details -->
             <DivideItem>
               <LabelValue label="More Details:">
                 <template #value>
@@ -408,40 +434,9 @@ useHead({
                 </template>
               </LabelValue>
             </DivideItem>
+
           </Divide>
         </div>
-      </div>
-
-      <div
-        v-if="activeView === 'neighbors'"
-        class="bg-[#111111] border border-[#222222] rounded-xl shadow-[0_0_20px_rgba(255,255,255,0.0625)] p-5"
-      >
-        <div
-          v-if="block.neighbors && block.neighbors.length > 0"
-          class="flex flex-col gap-4"
-        >
-          <div
-            v-for="neighbor in block.neighbors"
-            :key="neighbor.hash"
-            class="flex items-center"
-          >
-            <span class="text-[#bbbbbb] text-[15px] min-w-[300px]">Chain {{ neighbor.chainId }}</span>
-            <div class="flex items-center gap-2">
-              <NuxtLink
-                :to="`/blocks/${block.height}/chain/${neighbor.chainId}`"
-                class="text-[15px] text-[#6ab5db] hover:text-[#9ccee7]"
-                >{{ neighbor.hash }}</NuxtLink
-              >
-              <Copy
-                :value="neighbor.hash"
-                tooltipText="Copy Block Hash"
-                iconSize="h-5 w-5"
-                buttonClass="w-5 h-5"
-              />
-            </div>
-          </div>
-        </div>
-        <div v-else class="text-gray-500">No neighbors found for this block.</div>
       </div>
     </div>
   </div>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -14,6 +14,31 @@ definePageMeta({
   layout: 'app',
 });
 
+const textContent = {
+  blockHeight: { label: 'Block Height:', description: 'The unique number identifying the block in the blockchain, also known as its position in the chain.' },
+  chainId: { label: 'Chain ID', description: 'The specific chain (0-19) on which this block was mined.' },
+  status: { label: 'Status', description: 'The current confirmation status of the block. Canonical means it is part of the main chain.' },
+  creationTime: { label: 'Creation Time', description: 'The timestamp when the block was created by the miner.' },
+  transactions: { label: 'Transactions', description: 'The list of transactions included in this block.' },
+  events: { label: 'Events', description: 'The total number of events emitted by the transactions in this block.' },
+  minerAccount: { label: 'Miner Account', description: 'The address of the account that mined this block.' },
+  blockReward: { label: 'Block Reward', description: 'The amount of KDA awarded for mining this block.' },
+  difficulty: { label: 'Difficulty', description: 'A measure of how difficult it was to find a hash below the target for this block.' },
+  gasUsed: { label: 'Gas Used', description: 'The total amount of gas consumed by all transactions in this block.' },
+  gasLimit: { label: 'Gas Limit', description: 'The maximum amount of gas that can be used in a block.' },
+  nonce: { label: 'Nonce', description: 'A random value used by miners to create a valid proof-of-work hash.' },
+  epoch: { label: 'Epoch', description: 'The start date and time of the current epoch.' },
+  flags: { label: 'Flags', description: 'Hex-encoded bits used for validation.' },
+  target: { label: 'Target', description: 'The boundary below which the block hash must be for the block to be valid.' },
+  weight: { label: 'Weight', description: 'A measure of the total difficulty of the chain up to this block.' },
+  hash: { label: 'Hash', description: 'The unique identifier for this block (also known as Block Header Hash).' },
+  parentHash: { label: 'Parent Hash', description: 'The hash of the preceding block in this chain.' },
+  powHash: { label: 'POW Hash', description: 'The result of the proof-of-work computation.' },
+  payloadHash: { label: 'Payload Hash', description: 'The hash of all transactions and their outputs in this block.' },
+  moreDetails: { label: 'More Details:', description: 'Show or hide additional block details.' },
+  neighbor: { label: 'Neighbor at Chain #', description: 'A block at the same height on a different chain.' },
+};
+
 const activeView = ref('overview');
 
 const { formatFullDate, truncateAddress } = useFormat();
@@ -174,7 +199,7 @@ useHead({
             <!-- Section 1: Core Information -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue label="Block Height">
+                <LabelValue :label="textContent.blockHeight.label" :description="textContent.blockHeight.description">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span class="text-[#f5f5f5]">{{ block.height }}</span>
@@ -209,7 +234,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue label="Chain ID">
+                <LabelValue :label="textContent.chainId.label" :description="textContent.chainId.description">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ String(block.chainId) }}</span>
@@ -236,7 +261,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue label="Status">
+                <LabelValue :label="textContent.status.label" :description="textContent.status.description">
                   <template #value>
                     <div
                       v-if="blockStatus"
@@ -250,7 +275,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue label="Creation Time">
+                <LabelValue :label="textContent.creationTime.label" :description="textContent.creationTime.description">
                   <template #value>
                     <div class="flex items-center gap-1 text-white">
                       <IconClock class="w-4 h-4" />
@@ -258,7 +283,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue label="Transactions">
+                <LabelValue :label="textContent.transactions.label" :description="textContent.transactions.description">
                   <template #value>
                     <Tooltip value="Click to view Transactions">
                       <NuxtLink
@@ -271,7 +296,8 @@ useHead({
                   </template>
                 </LabelValue>
                 <LabelValue
-                  label="Events"
+                  :label="textContent.events.label"
+                  :description="textContent.events.description"
                   :value="`${block.events.totalCount} events`"
                 />
               </div>
@@ -280,7 +306,7 @@ useHead({
             <!-- Section 2: Miner and Difficulty -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue label="Miner Account">
+                <LabelValue :label="textContent.minerAccount.label" :description="textContent.minerAccount.description">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <Tooltip :value="minerAccount" variant="hash">
@@ -301,19 +327,19 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue label="Block Reward">
+                <LabelValue :label="textContent.blockReward.label" :description="textContent.blockReward.description">
                   <template #value v-if="blockReward != null">
                     {{ blockReward }} KDA
                   </template>
                 </LabelValue>
-                <LabelValue label="Difficulty" :value="block.difficulty" />
+                <LabelValue :label="textContent.difficulty.label" :description="textContent.difficulty.description" :value="block.difficulty" />
               </div>
             </DivideItem>
 
             <!-- Section 3: Gas -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue label="Gas Used">
+                <LabelValue :label="textContent.gasUsed.label" :description="textContent.gasUsed.description">
                   <template #value>
                     <span v-if="gasLoading">Calculating...</span>
                     <GasUsage
@@ -323,8 +349,8 @@ useHead({
                     />
                   </template>
                 </LabelValue>
-                <LabelValue label="Gas Limit" value="150,000" />
-                <LabelValue label="Nonce" :value="block.nonce" />
+                <LabelValue :label="textContent.gasLimit.label" :description="textContent.gasLimit.description" value="150,000" />
+                <LabelValue :label="textContent.nonce.label" :description="textContent.nonce.description" :value="block.nonce" />
               </div>
             </DivideItem>
           </Divide>
@@ -340,27 +366,63 @@ useHead({
             <DivideItem v-if="showMore">
               <div class="flex flex-col gap-4">
                 <LabelValue
-                  label="Epoch"
-                  :value="formatFullDate(block.epoch)"
-                />
-                <LabelValue label="Flags" :value="block.flags" />
-                <LabelValue label="Target" :value="block.target" />
-                <LabelValue label="Weight" :value="block.weight" />
+                  :label="textContent.epoch.label"
+                  :description="textContent.epoch.description"
+                >
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ formatFullDate(block.epoch) }}</span>
+                    </div>
+                  </template>
+                </LabelValue>
+                <LabelValue :label="textContent.flags.label" :description="textContent.flags.description">
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.flags }}</span>
+                    </div>
+                  </template>
+                </LabelValue>
+                <LabelValue :label="textContent.target.label" :description="textContent.target.description">
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.target }}</span>
+                    </div>
+                  </template>
+                </LabelValue>
+                <LabelValue :label="textContent.weight.label" :description="textContent.weight.description">
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.weight }}</span>
+                    </div>
+                  </template>
+                </LabelValue>
               </div>
             </DivideItem>
 
             <!-- Hash -->
             <DivideItem v-if="showMore">
               <div class="flex flex-col gap-4">
-                <LabelValue label="Hash" :value="block.hash" />
-                <LabelValue label="Parent Hash">
+                <LabelValue :label="textContent.hash.label" :description="textContent.hash.description">
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.hash }}</span>
+                      <Copy
+                        :value="block.hash"
+                        tooltipText="Copy Hash"
+                        iconSize="h-5 w-5"
+                        buttonClass="w-5 h-5"
+                      />
+                    </div>
+                  </template>
+                </LabelValue>
+                <LabelValue :label="textContent.parentHash.label" :description="textContent.parentHash.description">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <NuxtLink
-                        :to="`/blocks/${block.parent.height}/chain/${block.parent.chainId}`"
-                        class="text-[#6ab5db] hover:text-[#9ccee7]"
-                      >
-                        {{ block.parent.hash }}
+                          :to="`/blocks/${block.parent.height}/chain/${block.parent.chainId}`"
+                          class="text-[#6ab5db] hover:text-[#9ccee7]"
+                        >
+                          {{ block.parent.hash }}
                       </NuxtLink>
                       <Copy
                         :value="block.parent.hash"
@@ -371,14 +433,32 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue
-                  label="POW Hash"
-                  :value="block.powHash"
-                />
-                <LabelValue
-                  label="Payload Hash"
-                  :value="block.payloadHash"
-                />
+                <LabelValue :label="textContent.powHash.label" :description="textContent.powHash.description">
+                   <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.powHash }}</span>
+                      <Copy
+                        :value="block.powHash"
+                        tooltip-text="Copy POW Hash"
+                        iconSize="h-5 w-5"
+                        buttonClass="w-5 h-5"
+                      />
+                    </div>
+                  </template>
+                </LabelValue>
+                <LabelValue :label="textContent.payloadHash.label" :description="textContent.payloadHash.description">
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.payloadHash }}</span>
+                      <Copy
+                        :value="block.payloadHash"
+                        tooltip-text="Copy Payload Hash"
+                        iconSize="h-5 w-5"
+                        buttonClass="w-5 h-5"
+                      />
+                    </div>
+                  </template>
+                </LabelValue>
               </div>
             </DivideItem>
 
@@ -388,33 +468,35 @@ useHead({
                 v-if="block.neighbors && block.neighbors.length > 0"
                 class="flex flex-col gap-4"
               >
-                <div
+                <LabelValue
                   v-for="neighbor in block.neighbors"
                   :key="neighbor.hash"
-                  class="flex items-center"
+                  :label="`${textContent.neighbor.label}${neighbor.chainId}`"
+                  :description="textContent.neighbor.description"
                 >
-                  <span class="text-[#bbbbbb] text-[15px] min-w-[300px]">Neighbor at Chain #{{ neighbor.chainId }}</span>
-                  <div class="flex items-center gap-2">
-                    <NuxtLink
-                      :to="`/blocks/${block.height}/chain/${neighbor.chainId}`"
-                      class="text-[15px] text-[#6ab5db] hover:text-[#9ccee7]"
-                      >{{ neighbor.hash }}</NuxtLink
-                    >
-                    <Copy
-                      :value="neighbor.hash"
-                      tooltipText="Copy Block Hash"
-                      iconSize="h-5 w-5"
-                      buttonClass="w-5 h-5"
-                    />
-                  </div>
-                </div>
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <NuxtLink
+                        :to="`/blocks/${block.height}/chain/${neighbor.chainId}`"
+                        class="text-[15px] text-[#6ab5db] hover:text-[#9ccee7]"
+                        >{{ neighbor.hash }}</NuxtLink
+                      >
+                      <Copy
+                        :value="neighbor.hash"
+                        tooltipText="Copy Block Hash"
+                        iconSize="h-5 w-5"
+                        buttonClass="w-5 h-5"
+                      />
+                    </div>
+                  </template>
+                </LabelValue>
               </div>
-              <div v-else class="text-gray-500">No neighbors found for this block.</div>         
+              <div v-else class="text-gray-500">No neighbors found for this block.</div>
             </DivideItem>
 
             <!-- More Details -->
             <DivideItem>
-              <LabelValue label="More Details:">
+              <LabelValue :label="textContent.moreDetails.label" :description="textContent.moreDetails.description">
                 <template #value>
                   <button
                     @click="showMore = !showMore"
@@ -432,7 +514,6 @@ useHead({
                 </template>
               </LabelValue>
             </DivideItem>
-
           </Divide>
         </div>
       </div>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -72,7 +72,7 @@ const block = computed(() => {
 });
 
 const blockStatus = computed(() => {
-  if(lastBlockHeight.value - 6 >= block.value.height && !block.value.canonical) {
+  if(lastBlockHeight.value - 10 >= block.value.height && !block.value.canonical) {
     return {
       text: 'Orphaned',
       icon: IconCancel,
@@ -199,13 +199,13 @@ useHead({
       >
     </div>
 
-    <SkeletonBlockDetails v-if="loading" />
+    <SkeletonBlockDetails v-if="loading && !pollingInterval" />
 
     <div
       v-else-if="error || !block"
       class="bg-[#111111] border items-center justify-center border-[#222222] rounded-xl p-8 text-white"
     >
-      Block not found. It may not exist or has not been indexed yet. TODO: Cooler screen for this :D 
+      Block not found. It may not exist or has not been indexed yet. I own you a cool screen displaying the estimated time to index this block.
     </div>
 
     <div v-else>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -443,12 +443,6 @@ useHead({
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.hash }}</span>
-                      <Copy
-                        :value="block.hash"
-                        tooltipText="Copy Hash"
-                        iconSize="h-5 w-5"
-                        buttonClass="w-5 h-5"
-                      />
                     </div>
                   </template>
                 </LabelValue>
@@ -474,12 +468,6 @@ useHead({
                    <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.powHash }}</span>
-                      <Copy
-                        :value="block.powHash"
-                        tooltip-text="Copy POW Hash"
-                        iconSize="h-5 w-5"
-                        buttonClass="w-5 h-5"
-                      />
                     </div>
                   </template>
                 </LabelValue>
@@ -487,12 +475,7 @@ useHead({
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.payloadHash }}</span>
-                      <Copy
-                        :value="block.payloadHash"
-                        tooltip-text="Copy Payload Hash"
-                        iconSize="h-5 w-5"
-                        buttonClass="w-5 h-5"
-                      />
+
                     </div>
                   </template>
                 </LabelValue>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -17,26 +17,26 @@ definePageMeta({
 
 const textContent = {
   blockHeight: { label: 'Block Height:', description: 'The unique number identifying the block in the blockchain, also known as its position in the chain.' },
-  chainId: { label: 'Chain ID', description: 'The specific chain (0-19) on which this block was mined.' },
-  status: { label: 'Status', description: 'The current confirmation status of the block. Canonical means it is part of the main chain.' },
-  creationTime: { label: 'Creation Time', description: 'The timestamp when the block was created by the miner.' },
-  transactions: { label: 'Transactions', description: 'The list of transactions included in this block.' },
-  events: { label: 'Events', description: 'The total number of events emitted by the transactions in this block.' },
-  minerAccount: { label: 'Miner Account', description: 'The address of the account that mined this block.' },
-  blockReward: { label: 'Block Reward', description: 'The amount of KDA awarded for mining this block.' },
-  difficulty: { label: 'Difficulty', description: 'A measure of how difficult it was to find a hash below the target for this block.' },
-  gasUsed: { label: 'Gas Used', description: 'The total amount of gas consumed by all transactions in this block.' },
-  gasLimit: { label: 'Gas Limit', description: 'The maximum amount of gas that can be used in a block.' },
-  nonce: { label: 'Nonce', description: 'A random value used by miners to create a valid proof-of-work hash.' },
-  epoch: { label: 'Epoch', description: 'The start date and time of the current epoch.' },
-  flags: { label: 'Flags', description: 'Hex-encoded bits used for validation.' },
-  target: { label: 'Target', description: 'The boundary below which the block hash must be for the block to be valid.' },
-  weight: { label: 'Weight', description: 'A measure of the total difficulty of the chain up to this block.' },
-  hash: { label: 'Hash', description: 'The unique identifier for this block (also known as Block Header Hash).' },
-  parentHash: { label: 'Parent Hash', description: 'The hash of the preceding block in this chain.' },
-  powHash: { label: 'POW Hash', description: 'The result of the proof-of-work computation.' },
-  payloadHash: { label: 'Payload Hash', description: 'The hash of all transactions and their outputs in this block.' },
-  moreDetails: { label: 'More Details:', description: 'Show or hide additional block details.' },
+  chainId: { label: 'Chain ID:', description: 'The specific chain (0-19) on which this block was mined.' },
+  status: { label: 'Status:', description: 'The current confirmation status of the block. Canonical means it is part of the main chain.' },
+  creationTime: { label: 'Creation Time:', description: 'The timestamp when the block was created by the miner.' },
+  transactions: { label: 'Transactions:', description: 'The list of transactions included in this block.' },
+  events: { label: 'Events:', description: 'The total number of events emitted by the transactions in this block.' },
+  minerAccount: { label: 'Miner Account:', description: 'The address of the account that mined this block.' },
+  blockReward: { label: 'Block Reward:', description: 'The amount of KDA awarded for mining this block.' },
+  difficulty: { label: 'Difficulty:', description: 'A measure of how difficult it was to find a hash below the target for this block.' },
+  gasUsed: { label: 'Gas Used:', description: 'The total amount of gas consumed by all transactions in this block.' },
+  gasLimit: { label: 'Gas Limit:', description: 'The maximum amount of gas that can be used in a block.' },
+  nonce: { label: 'Nonce:', description: 'A random value used by miners to create a valid proof-of-work hash.' },
+  epoch: { label: 'Epoch:', description: 'The start date and time of the current epoch.' },
+  flags: { label: 'Flags:', description: 'Hex-encoded bits used for validation.' },
+  target: { label: 'Target:', description: 'The boundary below which the block hash must be for the block to be valid.' },
+  weight: { label: 'Weight:', description: 'A measure of the total difficulty of the chain up to this block.' },
+  hash: { label: 'Hash:', description: 'The unique identifier for this block (also known as Block Header Hash).' },
+  parentHash: { label: 'Parent Hash:', description: 'The hash of the preceding block in this chain.' },
+  powHash: { label: 'POW Hash:', description: 'The result of the proof-of-work computation.' },
+  payloadHash: { label: 'Payload Hash:', description: 'The hash of all transactions and their outputs in this block.' },
+  moreDetails: { label: 'More Details', description: 'Show or hide additional block details.' },
   neighbor: { label: 'Neighbor at Chain #', description: 'A block at the same height on a different chain.' },
 };
 
@@ -233,7 +233,7 @@ useHead({
             <!-- Section 1: Core Information -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue :label="textContent.blockHeight.label" :description="textContent.blockHeight.description" tooltipPos="right">
+                <LabelValue :row="isMobile" :label="textContent.blockHeight.label" :description="textContent.blockHeight.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span class="text-[#f5f5f5]">{{ block.height }}</span>
@@ -268,7 +268,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.chainId.label" :description="textContent.chainId.description" tooltipPos="right">
+                <LabelValue :row="isMobile" :label="textContent.chainId.label" :description="textContent.chainId.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ String(block.chainId) }}</span>
@@ -295,7 +295,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.status.label" :description="textContent.status.description" tooltipPos="right">
+                <LabelValue :row="isMobile" :label="textContent.status.label" :description="textContent.status.description" tooltipPos="right">
                   <template #value>
                     <div
                       v-if="blockStatus"

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -251,7 +251,7 @@ useHead({
                         <Tooltip value="View next Chain" :offset-distance="8">
                           <button
                             @click="goToBlock(height, chainId + 1)"
-                            :disabled="chainId === 20"
+                            :disabled="chainId === 19"
                             class="relative whitespace-nowrap inline-flex items-center p-1 rounded-md border border-[#222222] bg-[#111111] text-xs font-normal text-[#6ab5db] hover:text-[#fafafa] hover:bg-[#0784c3] disabled:hover:bg-[#151515] disabled:bg-[#151515] disabled:text-[#888888] transition-colors duration-300"
                           >
                             <IconChevron class="h-3 w-3" />

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -343,9 +343,7 @@ useHead({
               <div class="flex flex-col gap-4">
                 <LabelValue :label="textContent.gasUsed.label" :description="textContent.gasUsed.description" tooltipPos="right">
                   <template #value>
-                    <span v-if="gasLoading">Calculating...</span>
                     <GasUsage
-                      v-else
                       :gas="totalGasUsed"
                       :gas-limit="150000"
                     />

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -273,7 +273,7 @@ useHead({
                   <template #value>
                     <Tooltip value="Click to view Transactions">
                       <NuxtLink
-                        :to="`/transactions?block=${block.hash}`"
+                        :to="`/transactions?block=${block.hash}&chainId=${block.chainId}`"
                         class="text-[#6ab5db] hover:text-[#9ccee7]"
                       >
                         {{ block.transactions.totalCount }} transactions

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -93,10 +93,6 @@ watch(
 );
 
 const blockStatus = computed(() => {
-  if (!block.value || !lastBlockHeight.value) {
-    return null;
-  }
-
   if(lastBlockHeight.value - 8 >= block.value.height && !block.value.canonical) {
     return {
       text: 'Orphaned',

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -199,7 +199,7 @@ useHead({
             <!-- Section 1: Core Information -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue :label="textContent.blockHeight.label" :description="textContent.blockHeight.description">
+                <LabelValue :label="textContent.blockHeight.label" :description="textContent.blockHeight.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span class="text-[#f5f5f5]">{{ block.height }}</span>
@@ -234,7 +234,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.chainId.label" :description="textContent.chainId.description">
+                <LabelValue :label="textContent.chainId.label" :description="textContent.chainId.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ String(block.chainId) }}</span>
@@ -261,7 +261,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.status.label" :description="textContent.status.description">
+                <LabelValue :label="textContent.status.label" :description="textContent.status.description" tooltipPos="right">
                   <template #value>
                     <div
                       v-if="blockStatus"
@@ -275,7 +275,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.creationTime.label" :description="textContent.creationTime.description">
+                <LabelValue :label="textContent.creationTime.label" :description="textContent.creationTime.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-1 text-white">
                       <IconClock class="w-4 h-4" />
@@ -283,7 +283,12 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.transactions.label" :description="textContent.transactions.description">
+                <LabelValue
+                  :label="textContent.transactions.label"
+                  :value="block.transactions.totalCount"
+                  :description="textContent.transactions.description"
+                  tooltipPos="right"
+                >
                   <template #value>
                     <Tooltip value="Click to view Transactions">
                       <NuxtLink
@@ -299,6 +304,7 @@ useHead({
                   :label="textContent.events.label"
                   :description="textContent.events.description"
                   :value="`${block.events.totalCount} events`"
+                  tooltipPos="right"
                 />
               </div>
             </DivideItem>
@@ -306,7 +312,7 @@ useHead({
             <!-- Section 2: Miner and Difficulty -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue :label="textContent.minerAccount.label" :description="textContent.minerAccount.description">
+                <LabelValue :label="textContent.minerAccount.label" :description="textContent.minerAccount.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <Tooltip :value="minerAccount" variant="hash">
@@ -327,19 +333,19 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.blockReward.label" :description="textContent.blockReward.description">
+                <LabelValue :label="textContent.blockReward.label" :description="textContent.blockReward.description" tooltipPos="right">
                   <template #value v-if="blockReward != null">
                     {{ blockReward }} KDA
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.difficulty.label" :description="textContent.difficulty.description" :value="block.difficulty" />
+                <LabelValue :label="textContent.difficulty.label" :description="textContent.difficulty.description" :value="block.difficulty" tooltipPos="right" />
               </div>
             </DivideItem>
 
             <!-- Section 3: Gas -->
             <DivideItem>
               <div class="flex flex-col gap-4">
-                <LabelValue :label="textContent.gasUsed.label" :description="textContent.gasUsed.description">
+                <LabelValue :label="textContent.gasUsed.label" :description="textContent.gasUsed.description" tooltipPos="right">
                   <template #value>
                     <span v-if="gasLoading">Calculating...</span>
                     <GasUsage
@@ -349,8 +355,8 @@ useHead({
                     />
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.gasLimit.label" :description="textContent.gasLimit.description" value="150,000" />
-                <LabelValue :label="textContent.nonce.label" :description="textContent.nonce.description" :value="block.nonce" />
+                <LabelValue :label="textContent.gasLimit.label" :description="textContent.gasLimit.description" value="150,000" tooltipPos="right" />
+                <LabelValue :label="textContent.nonce.label" :description="textContent.nonce.description" :value="block.nonce" tooltipPos="right" />
               </div>
             </DivideItem>
           </Divide>
@@ -368,6 +374,7 @@ useHead({
                 <LabelValue
                   :label="textContent.epoch.label"
                   :description="textContent.epoch.description"
+                  tooltipPos="right"
                 >
                   <template #value>
                     <div class="flex items-center gap-2">
@@ -375,21 +382,21 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.flags.label" :description="textContent.flags.description">
+                <LabelValue :label="textContent.flags.label" :description="textContent.flags.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.flags }}</span>
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.target.label" :description="textContent.target.description">
+                <LabelValue :label="textContent.target.label" :description="textContent.target.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.target }}</span>
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.weight.label" :description="textContent.weight.description">
+                <LabelValue :label="textContent.weight.label" :description="textContent.weight.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.weight }}</span>
@@ -402,7 +409,7 @@ useHead({
             <!-- Hash -->
             <DivideItem v-if="showMore">
               <div class="flex flex-col gap-4">
-                <LabelValue :label="textContent.hash.label" :description="textContent.hash.description">
+                <LabelValue :label="textContent.hash.label" :description="textContent.hash.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.hash }}</span>
@@ -415,7 +422,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.parentHash.label" :description="textContent.parentHash.description">
+                <LabelValue :label="textContent.parentHash.label" :description="textContent.parentHash.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <NuxtLink
@@ -433,7 +440,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.powHash.label" :description="textContent.powHash.description">
+                <LabelValue :label="textContent.powHash.label" :description="textContent.powHash.description" tooltipPos="right">
                    <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.powHash }}</span>
@@ -446,7 +453,7 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.payloadHash.label" :description="textContent.payloadHash.description">
+                <LabelValue :label="textContent.payloadHash.label" :description="textContent.payloadHash.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.payloadHash }}</span>
@@ -473,6 +480,7 @@ useHead({
                   :key="neighbor.hash"
                   :label="`${textContent.neighbor.label}${neighbor.chainId}`"
                   :description="textContent.neighbor.description"
+                  tooltipPos="right"
                 >
                   <template #value>
                     <div class="flex items-center gap-2">
@@ -496,7 +504,7 @@ useHead({
 
             <!-- More Details -->
             <DivideItem>
-              <LabelValue :label="textContent.moreDetails.label" :description="textContent.moreDetails.description">
+              <LabelValue :label="textContent.moreDetails.label" :description="textContent.moreDetails.description" tooltipPos="right">
                 <template #value>
                   <button
                     @click="showMore = !showMore"

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -372,12 +372,10 @@ useHead({
                   </template>
                 </LabelValue>
                 <LabelValue
-                  tooltipText="Copy POW Hash"
                   label="POW Hash"
                   :value="block.powHash"
                 />
                 <LabelValue
-                  tooltipText="Copy Payload Hash"
                   label="Payload Hash"
                   :value="block.payloadHash"
                 />

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -360,14 +360,18 @@ useHead({
                 <LabelValue label="Parent Hash">
                   <template #value>
                     <div class="flex items-center gap-2">
-                      <Tooltip :value="block.parent.hash" variant="hash">
-                        <NuxtLink
-                          :to="`/blocks/${block.parent.height}/chain/${block.parent.chainId}`"
-                          class="text-[#6ab5db] hover:text-[#9ccee7]"
-                        >
-                          {{ block.parent.hash }}
-                        </NuxtLink>
-                      </Tooltip>
+                      <NuxtLink
+                        :to="`/blocks/${block.parent.height}/chain/${block.parent.chainId}`"
+                        class="text-[#6ab5db] hover:text-[#9ccee7]"
+                      >
+                        {{ block.parent.hash }}
+                      </NuxtLink>
+                      <Copy
+                        :value="block.parent.hash"
+                        tooltipText="Copy Parent Hash"
+                        iconSize="h-5 w-5"
+                        buttonClass="w-5 h-5"
+                      />
                     </div>
                   </template>
                 </LabelValue>
@@ -426,6 +430,12 @@ useHead({
                 class="text-[15px] text-[#6ab5db] hover:text-[#9ccee7]"
                 >{{ neighbor.hash }}</NuxtLink
               >
+              <Copy
+                :value="neighbor.hash"
+                tooltipText="Copy Block Hash"
+                iconSize="h-5 w-5"
+                buttonClass="w-5 h-5"
+              />
             </div>
           </div>
         </div>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -16,28 +16,28 @@ definePageMeta({
 });
 
 const textContent = {
-  blockHeight: { label: 'Block Height:', description: 'The unique number identifying the block in the blockchain, also known as its position in the chain.' },
-  chainId: { label: 'Chain ID:', description: 'The specific chain (0-19) on which this block was mined.' },
-  status: { label: 'Status:', description: 'The current confirmation status of the block. Canonical means it is part of the main chain.' },
-  creationTime: { label: 'Creation Time:', description: 'The timestamp when the block was created by the miner.' },
-  transactions: { label: 'Transactions:', description: 'The list of transactions included in this block.' },
-  events: { label: 'Events:', description: 'The total number of events emitted by the transactions in this block.' },
-  minerAccount: { label: 'Miner Account:', description: 'The address of the account that mined this block.' },
-  blockReward: { label: 'Block Reward:', description: 'The amount of KDA awarded for mining this block.' },
-  difficulty: { label: 'Difficulty:', description: 'A measure of how difficult it was to find a hash below the target for this block.' },
-  gasUsed: { label: 'Gas Used:', description: 'The total amount of gas consumed by all transactions in this block.' },
-  gasLimit: { label: 'Gas Limit:', description: 'The maximum amount of gas that can be used in a block.' },
-  nonce: { label: 'Nonce:', description: 'A random value used by miners to create a valid proof-of-work hash.' },
-  epoch: { label: 'Epoch:', description: 'The start date and time of the current epoch.' },
-  flags: { label: 'Flags:', description: 'Hex-encoded bits used for validation.' },
-  target: { label: 'Target:', description: 'The boundary below which the block hash must be for the block to be valid.' },
-  weight: { label: 'Weight:', description: 'A measure of the total difficulty of the chain up to this block.' },
-  hash: { label: 'Hash:', description: 'The unique identifier for this block (also known as Block Header Hash).' },
-  parentHash: { label: 'Parent Hash:', description: 'The hash of the preceding block in this chain.' },
-  powHash: { label: 'POW Hash:', description: 'The result of the proof-of-work computation.' },
-  payloadHash: { label: 'Payload Hash:', description: 'The hash of all transactions and their outputs in this block.' },
-  moreDetails: { label: 'More Details', description: 'Show or hide additional block details.' },
-  neighbor: { label: 'Neighbor at Chain #', description: 'A block at the same height on a different chain.' },
+  blockHeight: { label: 'Block Height:', description: 'The unique numerical position of the block in the blockchain' },
+  chainId: { label: 'Chain ID:', description: 'The specific chain (0-19) on which this block was mined' },
+  status: { label: 'Status:', description: 'Indicates if the block is confirmed and part of the canonical chain' },
+  creationTime: { label: 'Creation Time:', description: 'Timestamp when the block was created' },
+  transactions: { label: 'Transactions:', description: 'Transactions included in this block' },
+  events: { label: 'Events:', description: 'Number of events emitted by the block’s transactions' },
+  minerAccount: { label: 'Miner Account:', description: 'Address of the miner who produced this block' },
+  blockReward: { label: 'Block Reward:', description: 'Amount of KDA awarded for mining this block' },
+  difficulty: { label: 'Difficulty:', description: 'A measure of how difficult it was to find a hash below the target for this block' },
+  gasUsed: { label: 'Gas Used:', description: 'Total gas consumed by transactions in this block' },
+  gasLimit: { label: 'Gas Limit:', description: 'Maximum gas allowed in the block' },
+  nonce: { label: 'Nonce:', description: 'A random value used by miners to create a valid proof-of-work hash' },
+  epoch: { label: 'Epoch:', description: 'Start time of the current epoch' },
+  flags: { label: 'Flags:', description: 'Hex-encoded bits used for configuration' },
+  target: { label: 'Target:', description: 'Hash must be below this value to be valid' },
+  weight: { label: 'Weight:', description: 'Cumulative difficulty up to this block' },
+  hash: { label: 'Hash:', description: 'Unique hash of this block (header hash)' },
+  parentHash: { label: 'Parent Hash:', description: 'Hash of the previous block in this chain' },
+  powHash: { label: 'POW Hash:', description: 'Hash result of the proof-of-work computation' },
+  payloadHash: { label: 'Payload Hash:', description: 'Hash of the block’s transaction payload' },
+  neighbor: { label: 'Neighbor at Chain #', description: 'Block at same height on another chain' },
+  moreDetails: { label: 'More Details' },
 };
 
 
@@ -329,7 +329,7 @@ useHead({
                         :to="`/transactions?block=${block.height}&chainId=${block.chainId}`"
                         class="text-[#6ab5db] hover:text-[#9ccee7]"
                       >
-                        {{ block.transactions.totalCount }} transactions
+                        {{ block.transactions.totalCount }} transactions in this block
                       </NuxtLink>
                     </Tooltip>
                   </template>
@@ -337,7 +337,7 @@ useHead({
                 <LabelValue
                   :label="textContent.events.label"
                   :description="textContent.events.description"
-                  :value="`${block.events.totalCount} events`"
+                  :value="`${block.events.totalCount} events in this block`"
                   tooltipPos="right"
                 />
               </div>
@@ -421,17 +421,17 @@ useHead({
                     </div>
                   </template>
                 </LabelValue>
-                <LabelValue :label="textContent.target.label" :description="textContent.target.description" tooltipPos="right">
-                  <template #value>
-                    <div class="flex items-center gap-2">
-                      <span>{{ block.target }}</span>
-                    </div>
-                  </template>
-                </LabelValue>
                 <LabelValue :label="textContent.weight.label" :description="textContent.weight.description" tooltipPos="right">
                   <template #value>
                     <div class="flex items-center gap-2">
                       <span>{{ block.weight }}</span>
+                    </div>
+                  </template>
+                </LabelValue>
+                <LabelValue :label="textContent.target.label" :description="textContent.target.description" tooltipPos="right">
+                  <template #value>
+                    <div class="flex items-center gap-2">
+                      <span>{{ block.target }}</span>
                     </div>
                   </template>
                 </LabelValue>
@@ -521,7 +521,6 @@ useHead({
             <DivideItem>
               <LabelValue
                 :label="isMobile ? '' : textContent.moreDetails.label"
-                :description="textContent.moreDetails.description"
                 tooltipPos="right"
               >
                 <template #value>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
-import { ref, computed, watch, onUnmounted } from 'vue';
+import { ref, computed, watch, onUnmounted, onMounted } from 'vue';
 import { useFormat } from '~/composables/useFormat';
 import { useBlock } from '~/composables/useBlock';
 import { useBlocks } from '~/composables/useBlocks';
 import { useSharedData } from '~/composables/useSharedData';
+import { useScreenSize } from '~/composables/useScreenSize';
 import IconCheckmarkFill from '~/components/icon/CheckmarkFill.vue';
 import IconHourglass from '~/components/icon/Hourglass.vue';
 import IconCancel from '~/components/icon/Cancel.vue';
@@ -43,6 +44,7 @@ const textContent = {
 const { formatFullDate, truncateAddress } = useFormat();
 const route = useRoute();
 const router = useRouter();
+const { isMobile } = useScreenSize();
 const { selectedNetwork } = useSharedData();
 const { totalCount: lastBlockHeight, fetchTotalCount } = useBlocks();
 
@@ -517,18 +519,22 @@ useHead({
 
             <!-- More Details -->
             <DivideItem>
-              <LabelValue :label="textContent.moreDetails.label" :description="textContent.moreDetails.description" tooltipPos="right">
+              <LabelValue
+                :label="isMobile ? '' : textContent.moreDetails.label"
+                :description="textContent.moreDetails.description"
+                tooltipPos="right"
+              >
                 <template #value>
                   <button
                     @click="showMore = !showMore"
                     class="text-[#6ab5db] hover:text-[#9ccee7] flex items-center gap-1 whitespace-nowrap"
                   >
                     <template v-if="!showMore">
-                      <span>+</span>
+                      <span v-if="!isMobile">+</span>
                       <span>Click to show more</span>
                     </template>
                     <template v-else>
-                      <span>-</span>
+                      <span v-if="!isMobile">-</span>
                       <span>Click to show less</span>
                     </template>
                   </button>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -28,7 +28,7 @@ const textContent = {
   difficulty: { label: 'Difficulty:', description: 'A measure of how difficult it was to find a hash below the target for this block' },
   gasUsed: { label: 'Gas Used:', description: 'Total gas consumed by transactions in this block' },
   gasLimit: { label: 'Gas Limit:', description: 'Maximum gas allowed in the block' },
-  kadenaPrice: { label: 'Kadena Price:', description: 'Price of Kadena at the time this block was created' },
+  kadenaPrice: { label: 'Kadena Price:', description: 'Closing price of Kadena on date of transaction' },
   nonce: { label: 'Nonce:', description: 'A random value used by miners to create a valid proof-of-work hash' },
   epoch: { label: 'Epoch:', description: 'Start time of the current epoch' },
   flags: { label: 'Flags:', description: 'Hex-encoded bits used for configuration' },
@@ -49,9 +49,7 @@ const router = useRouter();
 const { isMobile } = useScreenSize();
 const { selectedNetwork } = useSharedData();
 const { totalCount: lastBlockHeight, fetchTotalCount } = useBlocks();
-const { fetchKadenaPriceAtTimestamp } = useBinance();
 
-const kadenaPrice = ref(null);
 const activeView = ref('overview');
 const showMore = ref(false);
 const height = computed(() => Number(route.params.height));
@@ -68,6 +66,7 @@ const {
   canonicalIndex,
   totalGasUsed,
   gasLoading,
+  kadenaPrice,
 } = useBlock(height, chainId, networkId);
 
 const block = computed(() => {
@@ -110,6 +109,13 @@ const coinbaseData = computed(() => {
   } catch (e) {
     return null;
   }
+});
+
+const formattedKadenaPrice = computed(() => {
+  if (kadenaPrice.value === null) {
+    return 'N/A';
+  }
+  return `$${removeTrailingZeros(kadenaPrice.value)}`;
 });
 
 const minerAccount = computed(() => coinbaseData.value?.events?.[0]?.params?.[1]);
@@ -184,19 +190,6 @@ watch(
   (newIndex) => {
     if (newIndex !== -1) {
       selectedBlockIndex.value = newIndex;
-    }
-  },
-  { immediate: true }
-);
-
-watch(
-  () => block.value?.creationTime,
-  async (creationTime) => {
-    if (creationTime) {
-      const priceData = await fetchKadenaPriceAtTimestamp(creationTime);
-      if (priceData && priceData.price) {
-        kadenaPrice.value = `$${removeTrailingZeros(priceData.price)}`;
-      }
     }
   },
   { immediate: true }

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -271,12 +271,14 @@ useHead({
                 </LabelValue>
                 <LabelValue label="Transactions">
                   <template #value>
-                    <NuxtLink
-                      :to="`/transactions?block=${block.hash}`"
-                      class="text-[#6ab5db] hover:text-[#9ccee7]"
-                    >
-                      {{ block.transactions.totalCount }} transactions
-                    </NuxtLink>
+                    <Tooltip value="Click to view Transactions">
+                      <NuxtLink
+                        :to="`/transactions?block=${block.hash}`"
+                        class="text-[#6ab5db] hover:text-[#9ccee7]"
+                      >
+                        {{ block.transactions.totalCount }} transactions
+                      </NuxtLink>
+                    </Tooltip>
                   </template>
                 </LabelValue>
                 <LabelValue

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -383,6 +383,7 @@ useHead({
                   </template>
                 </LabelValue>
                 <LabelValue :label="textContent.difficulty.label" :description="textContent.difficulty.description" :value="block.difficulty" tooltipPos="right" />
+                <LabelValue :label="textContent.nonce.label" :description="textContent.nonce.description" :value="block.nonce" tooltipPos="right" />
               </div>
             </DivideItem>
 
@@ -399,7 +400,6 @@ useHead({
                 </LabelValue>
                 <LabelValue :label="textContent.gasLimit.label" :description="textContent.gasLimit.description" value="150,000" tooltipPos="right" />
                 <LabelValue :label="textContent.kadenaPrice.label" :description="textContent.kadenaPrice.description" :value="formattedKadenaPrice" tooltipPos="right" />
-                <LabelValue :label="textContent.nonce.label" :description="textContent.nonce.description" :value="block.nonce" tooltipPos="right" />
               </div>
             </DivideItem>
           </Divide>

--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -152,47 +152,6 @@ useHead({
     </div>
 
     <div v-else>
-      <div
-        v-if="competingBlocks.length > 1 && canonicalIndex === -1"
-        class="w-full p-4 text-center mb-1 text-[15px] rounded-xl border bg-red-900/40 border-red-400 text-red-400"
-      >
-        <span>
-          Multiple competing blocks have been detected. Please wait for one to
-          be finalized.
-        </span>
-      </div>
-
-      <div
-        v-if="competingBlocks.length > 1 && canonicalIndex !== -1"
-        class="w-full p-4 text-center mb-1 text-[15px] rounded-xl border bg-[#0f1f1d] border-[#00a186] text-[#00a186]"
-      >
-        <span v-if="canonicalIndex !== -1">
-          This block had multiple versions, and
-          <strong>Index {{ canonicalIndex }}</strong> is the canonical one.
-        </span>
-      </div>
-
-      <div
-        v-if="competingBlocks.length > 1"
-        class="pt-2 pb-5 flex gap-2 overflow-x-auto border-b border-[#222222] mb-6"
-      >
-        <button
-          v-for="(competingBlock, index) in competingBlocks.slice(0, 10)"
-          :key="index"
-          @click="selectedBlockIndex = index"
-          class="px-3 py-1.5 text-[13px] rounded-xl border transition-colors"
-          :class="
-            (canonicalIndex === index && selectedBlockIndex === index)
-              ? 'bg-[#0f1f1d] border border-[#00a186] rounded-lg text-[#00a186]'
-              : selectedBlockIndex === index
-              ? 'bg-[#7f1d1d66] border border-[#f87171] rounded-lg text-[#f87171]'
-              : 'bg-[#111111] border border-[#222222] rounded-lg text-[#bbbbbb] hover:bg-[#222222] hover:text-[#fafafa]'
-          "
-        >
-          Index {{ index }}
-        </button>
-      </div>
-
       <div class="flex items-center gap-2 mb-2">
         <button
           class="px-[10px] py-[5px] text-[13px] rounded-lg border font-medium transition-colors bg-[#009367] border-[#222222] text-[#f5f5f5]"
@@ -464,7 +423,7 @@ useHead({
             <div class="flex items-center gap-2">
               <NuxtLink
                 :to="`/blocks/${block.height}/chain/${neighbor.chainId}`"
-                class="text-[#6ab5db] hover:text-[#9ccee7]"
+                class="text-[15px] text-[#6ab5db] hover:text-[#9ccee7]"
                 >{{ neighbor.hash }}</NuxtLink
               >
             </div>

--- a/server/api/binance.post.ts
+++ b/server/api/binance.post.ts
@@ -5,6 +5,8 @@ const getApiEndpoint = (action: string, params: Record<string, any>) => {
   switch (action) {
     case 'getKadenaPrice':
       return `https://api.binance.com/api/v3/ticker/price?${query}`;
+    case 'getKadenaTickerData':
+      return `https://api.binance.com/api/v3/ticker/24hr?${query}`;
     case 'getKadenaCandlestickData':
       return `https://api.binance.com/api/v3/klines?${query}`;
     default:

--- a/server/api/binance.post.ts
+++ b/server/api/binance.post.ts
@@ -1,0 +1,42 @@
+import {H3Event} from 'h3';
+
+const getApiEndpoint = (action: string, params: Record<string, any>) => {
+  const query = new URLSearchParams(params).toString();
+  switch (action) {
+    case 'getKadenaPrice':
+      return `https://api.binance.com/api/v3/ticker/price?${query}`;
+    case 'getKadenaCandlestickData':
+      return `https://api.binance.com/api/v3/klines?${query}`;
+    default:
+      return null;
+  }
+};
+
+export default defineEventHandler(async (event: H3Event) => {
+  const {action, params} = await readBody(event);
+  const apiUrl = getApiEndpoint(action, params);
+
+  if (!apiUrl) {
+    return {
+      error: 'Invalid action',
+    };
+  }
+
+  try {
+    const response = await fetch(apiUrl);
+
+    if (!response.ok) {
+      throw new Error(`Binance API request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    return {
+      data,
+    };
+  } catch (error: any) {
+    return {
+      error: error.message,
+    };
+  }
+}); 


### PR DESCRIPTION
Part of #17 and a few others

- changed background color to a lighter color 
- fixed minor mobile styling on block details
- fixed tooltip placements
- near perfect skeleton for block details
- featuring Binance for fetching prices, defaulted to Binance and fallback is CoinGecko
- new format for trialling zeroes
- Block details update without any sort of transition, it's full smooth
- new global screen size checker