### PR TITLE
fix: pooling time of block status

### DIFF
--- a/pages/blocks/[height]/chain/[chainId].vue
+++ b/pages/blocks/[height]/chain/[chainId].vue
@@ -158,7 +158,7 @@ const startPolling = () => {
       fetchBlock();
       fetchTotalCount({ networkId: networkId.value });
     }
-  }, 2000);
+  }, 4000);
 };
 
 onUnmounted(() => {


### PR DESCRIPTION
Increased the pooling time by 2 seconds to avoid too many queries, It's still smooth, but doesn't constantly fire against the endpoint