### PR TITLE
fix: remove orphaned

### DIFF
--- a/composables/useTransactions.ts
+++ b/composables/useTransactions.ts
@@ -92,7 +92,6 @@ export const useTransactions = () => {
     loading.value = transactions.value.length === 0;
     try {
       const isForward = !!after || (!after && !before);
-      console.log("chainId", chainId);
       const response: any = await $fetch('/api/graphql', {
         method: 'POST',
         body: {


### PR DESCRIPTION
We discussed with Kadena and they think its better to now show orphaned transactions and blocks in the official list, only in the details page. This PR addresses that.