### PR TITLE
fix: clearing cache when mounting pages

### DIFF
--- a/composables/useBlocks.ts
+++ b/composables/useBlocks.ts
@@ -135,6 +135,14 @@ const blocksByHeight = ref<any[]>([]);
 const loadingByHeight = ref(true);
 
 export const useBlocks = () => {
+  const clearState = () => {
+    blocks.value = [];
+    blocksByHeight.value = [];
+    loading.value = true;
+    loadingByHeight.value = true;
+    pageInfo.value = null;
+  };
+
   const updateRowsToShow = (rows: any) => {
     rowsToShow.value = rows.value;
   };
@@ -272,5 +280,6 @@ export const useBlocks = () => {
     blocksByHeight,
     loadingByHeight,
     fetchBlocksByHeight,
+    clearState,
   };
 }; 

--- a/composables/useTransactions.ts
+++ b/composables/useTransactions.ts
@@ -55,6 +55,12 @@ const totalCount = ref(0);
 const rowsToShow = ref(25);
 
 export const useTransactions = () => {
+  const clearState = () => {
+    transactions.value = [];
+    loading.value = true;
+    pageInfo.value = null;
+  };
+
   const updateRowsToShow = (rows: any) => {
     rowsToShow.value = rows.value;
   };
@@ -145,5 +151,6 @@ export const useTransactions = () => {
     fetchTotalCount,
     rowsToShow,
     updateRowsToShow,
+    clearState,
   };
 }; 

--- a/pages/blocks/index.vue
+++ b/pages/blocks/index.vue
@@ -38,7 +38,8 @@ const {
   totalCount: lastBlockHeight,
   fetchTotalCount,
   rowsToShow,
-  updateRowsToShow
+  updateRowsToShow,
+  clearState,
 } = useBlocks();
 
 // Chain filter state - initialize from URL parameters
@@ -46,6 +47,9 @@ const selectedChain = ref({ label: 'All', value: null });
 
 // Initialize chain filter from URL parameter on component mount
 onMounted(() => {
+  // Clear global state to show skeleton on page navigation
+  clearState();
+  
   const chainParam = route.query.chain;
   if (chainParam && chainParam !== 'all') {
     const chainValue = parseInt(chainParam as string);

--- a/pages/transactions/index.vue
+++ b/pages/transactions/index.vue
@@ -42,11 +42,17 @@ const {
   totalCount, 
   fetchTotalCount, 
   rowsToShow, 
-  updateRowsToShow 
+  updateRowsToShow,
+  clearState,
 } = useTransactions();
 
 // Chain filter state - initialize from URL parameters (commented due to query glitch)
 const selectedChain = ref({ label: 'All', value: null });
+
+// Clear global state on mount to show skeleton on page navigation
+onMounted(() => {
+  clearState();
+});
 
 // Initialize chain filter from URL parameter on component mount (commented due to query glitch)
 // onMounted(() => {


### PR DESCRIPTION
We were facing a crazy bug with loading where the reset of the block/transaction count to 0 when mounting was forcing the "last" to trigger because of this:
```
    if(pageNumber === totalPages.value) {
      params.after = null;
      params.before = null;
      params.toLastPage = true;
    }
```
Which should only trigger when the user goes to the last page. since he was on the first page and the counter reseted, then 0 = 0.