### PR TITLE
refactor: search with code query new params

### DIFF
--- a/composables/search.ts
+++ b/composables/search.ts
@@ -87,6 +87,7 @@ const transactionsByPactCodeQuery = `
           canonical
           chainId
           creationTime
+          badResult
           gas
           gasLimit
           gasPrice
@@ -398,21 +399,16 @@ export function useSearch () {
 
             const edges = codeResponse?.data?.transactionsByPactCode?.edges || [];
             if (currentQuery === data.query && edges.length) {
-              // TEMP: convert unix seconds to ISO for creationTime until API returns ISO
-              const toIso = (v: any): string => {
-                if (typeof v === 'number') return new Date(v * 1000).toISOString();
-                if (typeof v === 'string' && /^\d+$/.test(v)) return new Date(parseInt(v, 10) * 1000).toISOString();
-                return new Date(v).toISOString();
-              };
-
               const codeItems = edges.map((edge: any) => {
                 const n = edge.node;
-                const resultString = '{"status":"success","badResult":null}';
+                const resultString = (n?.badResult !== null && n?.badResult !== undefined)
+                  ? `{"status":"error","badResult":${JSON.stringify(n.badResult)}}`
+                  : '{"status":"success","badResult":null}';
                 return {
                   requestkey: n.requestKey,
                   chainId: n.chainId,
                   height: n.height,
-                  creationTime: toIso(n.creationTime),
+                  creationTime: n.creationTime,
                   result: resultString,
                 };
               });

--- a/composables/useTransactionsByPactCode.ts
+++ b/composables/useTransactionsByPactCode.ts
@@ -16,6 +16,7 @@ const GQL_QUERY = `
           canonical
           chainId
           creationTime
+          badResult
           gas
           gasLimit
           gasPrice
@@ -91,12 +92,6 @@ export const useTransactionsByPactCode = () => {
       }
 
       const rawTxs = result.edges;
-      // TEMP: convert unix seconds to ISO until API returns ISO
-      const toIso = (v: any): string => {
-        if (typeof v === 'number') return new Date(v * 1000).toISOString();
-        if (typeof v === 'string' && /^\d+$/.test(v)) return new Date(parseInt(v, 10) * 1000).toISOString();
-        return new Date(v).toISOString();
-      };
 
       transactions.value = rawTxs.map((edge: any) => {
         const n = edge.node;
@@ -104,9 +99,9 @@ export const useTransactionsByPactCode = () => {
           requestKey: n.requestKey,
           height: n.height,
           canonical: n.canonical,
-          badResult: null,
+          badResult: n.badResult,
           chainId: n.chainId,
-          time: formatRelativeTime(toIso(n.creationTime)),
+          time: formatRelativeTime(n.creationTime),
           sender: n.sender,
           gasPrice: formatGasPrice(parseFloat(n.gasPrice)),
           rawGasPrice: n.gasPrice,

--- a/pages/transactions/[requestKey].vue
+++ b/pages/transactions/[requestKey].vue
@@ -329,6 +329,7 @@ const formattedGasInfo = computed(() => {
 
 // Execution Result badge mapping (Good/Bad)
 const executionResultBadge = computed(() => {
+  console.log('transactionExecutionResult', transactionExecutionResult.value)
   if (!transactionExecutionResult?.value) return null
   if (transactionExecutionResult.value.type === 'badResult') {
     return {
@@ -783,11 +784,6 @@ onUnmounted(() => {
                           <div class="flex-1 text-[#fafafa]">
                             {{ transactionExecutionResult.value }}
                           </div>
-                          <!-- <textarea
-                            readonly
-                            :value="transactionExecutionResult.value"
-                            class="flex-1 w-full min-w-0 bg-[#151515] border border-[#222222] rounded-lg text-[#bbbbbb] text-sm px-[10px] py-[8px] outline-none font-mono whitespace-pre-wrap overflow-auto break-all resize-none"
-                          ></textarea> -->
                         </div>
                       </template>
                     </LabelValue>


### PR DESCRIPTION
 This is to keep up with the changes on the Search Query by Pact code from the Graphql.
 
- creation time is received as iso string
- badResult is included for the status badge

https://github.com/hack-a-chain-software/indexer-kadena/pull/452
https://github.com/hack-a-chain-software/indexer-kadena/issues/416