### PR TITLE
fix: hydration and dim theme issue

### DIFF
--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -60,6 +60,11 @@
   --accent-strong: 0 178 140; /* #00b28c */
 }
 
+/* Hide until theme is applied on the client to prevent flashing the wrong theme */
+html:not([data-theme-ready="1"]) body {
+  visibility: hidden !important;
+}
+
 /* Dim theme */
 [data-theme="dim"] {
   /* Backgrounds & Surfaces */

--- a/composables/useTheme.ts
+++ b/composables/useTheme.ts
@@ -1,11 +1,21 @@
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { applyThemeAttribute, readStoredTheme, writeStoredTheme } from '~/lib/theme'
 
 export type AppTheme = 'light' | 'dim' | 'dark'
 
-const currentTheme = ref<AppTheme>(readStoredTheme())
+const currentTheme = ref<AppTheme>('light')
+let didInitFromStorage = false
 
 export function useTheme() {
+  if (process.client && !didInitFromStorage) {
+    didInitFromStorage = true
+    onMounted(() => {
+      const stored = readStoredTheme()
+      currentTheme.value = stored
+      applyThemeAttribute(stored)
+      try { document.documentElement.setAttribute('data-theme-ready', '1') } catch {}
+    })
+  }
   function setTheme(theme: AppTheme) {
     currentTheme.value = theme
     writeStoredTheme(theme)

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -25,8 +25,6 @@ export function writeStoredTheme(theme: AppTheme): void {
 export function applyThemeAttribute(theme: AppTheme): void {
   if (!isClient()) return
   const root = document.documentElement
-  // Ensure legacy .dark class does not interfere
-  root.removeAttribute('class')
   root.setAttribute('data-theme', theme)
 }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
       posthogHost: process.env.NUXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
       posthogDefaults: process.env.NUXT_PUBLIC_POSTHOG_DEFAULTS || '2025-05-24',
       // Optional toggle; we will still guard by production in the plugin
-      posthogEnabled: process.env.NUXT_PUBLIC_POSTHOG_ENABLED || 'true',
+      posthogEnabled: process.env.NUXT_PUBLIC_POSTHOG_ENABLED || 'false',
     },
   },
 


### PR DESCRIPTION
This problem is introduced due to a Vue HeadlessUI issue where they only assume light and dark as themes, so they present SSR error when loading the Dim theme on the server side, we must wait the server side to load as light/dark them change to dim to avoid this issue, incurring in a 0.1~0.2 to load the page, im sad, but nothing to do T.T